### PR TITLE
Stricter dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "bytes": "^1.0.0",
     "defaults": "^1.0.2",
     "gulp-util": "^3.0.4",
-    "node-zopfli": "^1.2.1",
+    "node-zopfli": "~1.2.1",
     "stream-to-array": "^2.0.2",
     "through2": "^0.6.3"
   },


### PR DESCRIPTION
Hi!

`node-zopfli` has updated and now not work in my environment:

Error: /lib64/libc.so.6: version `GLIBC_2.14' not found (required by /opt/buildAgent/work/e39aa71cc8a2c711/node_modules/gulp-zopfli/node_modules/node-zopfli/lib/binding/node-v11-linux-x64/zopfli.node)

I have only GLIBC_2.12, and can not update it.

This PR switch from `^1.2.1` (`>=1.2.1 <2.0.0`) to `~1.2.1` (`>=1.2.1 <1.3.0`)
